### PR TITLE
Video/slide button resize and mobile view fix

### DIFF
--- a/css/schedule.css
+++ b/css/schedule.css
@@ -128,8 +128,48 @@ body {
   opacity: 1;
   top:0;
 }
+
 .btn-sign-up {
   background: #ff8700;
   color: #FFFFFF;
   margin-left: 5px;
+  margin-top: -5px;
+}
+
+.video-link > .fa {
+	font-size: 22px;
+	color: #757575;
+}
+
+.video-link > .fa:hover {
+	color: #e52d27;
+}
+
+.video-link  {
+	margin-left: 3px;
+}
+
+.session-link > .fa {
+	font-size: 18px;
+	color: #757575;
+}
+
+.session-link > .fa:hover {
+	color: #2196F3;
+}
+
+@media (max-width: 450px) {
+	.session-link > .fa {
+		font-size: 24px;
+	}
+	.video-link > .fa {
+		font-size: 28px;
+	}
+	.btn-sign-up {
+		font-size: 15px;
+		margin-top: -8px;
+	}
+	.session-title {
+		line-height: 1.5; 
+	}
 }


### PR DESCRIPTION
The video and slideshow buttons have been resized to for a uniform look. The button are made bigger and the line-height for the session title is increased for mobile devices to make the button easily clickable.

Resolves #23 

Demo: http://niranjan94.github.io/2016.opentechsummit.net/programm/
